### PR TITLE
Enable ADG edx theme settings

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -396,10 +396,10 @@ if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
 # in it's path. Re-calling derive_settings doesn't work because the settings was already
 # changed from a function to a list, and it can't be derived again.
 
-# from .common import _make_mako_template_dirs
-# ENABLE_COMPREHENSIVE_THEMING = True
-# COMPREHENSIVE_THEME_DIRS = [
-#     "/edx/app/edxapp/edx-platform/themes/"
-# ]
-# TEMPLATES[1]["DIRS"] = _make_mako_template_dirs
-# derive_settings(__name__)
+from .common import _make_mako_template_dirs
+ENABLE_COMPREHENSIVE_THEMING = True
+COMPREHENSIVE_THEME_DIRS = [
+    "/edx/src/adg-edx-theme/edx-platform/"
+]
+TEMPLATES[1]["DIRS"] = _make_mako_template_dirs
+derive_settings(__name__)


### PR DESCRIPTION
[LP-2343](https://philanthropyu.atlassian.net/browse/LP-2343)
[Theme PR](https://github.com/OmnipreneurshipAcademy/adg-edx-theme/pull/1)
**Why did I enable it here?**
- We don't need to customize docker images.
- In this release edX recommends, to enable theme in devstack make changes in this file.
- edX has deprecated lms|cms.env.json files, and added .yml in production envs, in devstack I didn't find yml files, no documentation found.
