### PR TITLE
Change selector to pass correct data in i18n/setlang

### DIFF
--- a/common/static/js/src/lang_edx.js
+++ b/common/static/js/src/lang_edx.js
@@ -4,7 +4,7 @@ var Language = (function() {
         self = null;
     return {
         init: function() {
-            $settings_language_selector = $('#settings-language-value, input[name="radio-select-language"]');
+            $settings_language_selector = $('#settings-language-value, input[name="language"]');
             self = this;
             this.listenForLanguagePreferenceChange();
         },


### PR DESCRIPTION
[Theme PR](https://github.com/OmnipreneurshipAcademy/adg-edx-theme/pull/11)

Context:
- Whatever we use as the name of selector is being passed as data member to `i18n/setlang` API, previous implementation was sending `radio-select-language` as key which was not changing language at all.
- This is a bug in [LP-2341](https://philanthropyu.atlassian.net/browse/LP-2341), but was not captured, because in case you are not logged in this API is not used to setlang, that is totally a different mechanism and once you switched language in non logged in mode, it caches the the cookies and use them effectively. But whenever it would be tried after clearing cache, or on a new machine it will cause issue.
