### PR TITLE
LP-2456 Send updated course invitation email

### DIFF
--- a/openedx/adg/common/lib/mandrill_client/client.py
+++ b/openedx/adg/common/lib/mandrill_client/client.py
@@ -14,7 +14,7 @@ class MandrillClient(object):
     Mandrill class to send ADG emails
     """
     CHANGE_USER_EMAIL_ALERT = 'adg-confirm-email-address-change'
-    COURSE_ENROLLMENT_INVITATION = 'course-enrollment-invitation'
+    COURSE_ENROLLMENT_INVITATION = 'adg-invitation-course'
     ENROLLMENT_CONFIRMATION = 'adg-enrollment-confirmation'
     PASSWORD_RESET = 'adg-password-reset'
     USER_ACCOUNT_ACTIVATION = 'adg-user-activation-email'

--- a/openedx/adg/lms/student/helpers.py
+++ b/openedx/adg/lms/student/helpers.py
@@ -2,6 +2,7 @@
 Helpers for edx student app
 """
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.contrib.auth.tokens import default_token_generator
 from django.urls import reverse
 from django.utils.http import int_to_base36
@@ -148,6 +149,10 @@ def compose_and_send_adg_course_enrollment_invitation_email(user_email, message_
         message_context['course_name'] = message_context['display_name']
     elif 'course' in message_context:
         message_context['course_name'] = Text(message_context['course'].display_name_with_default)
+
+    user = User.objects.filter(email=user_email).select_related('profile').first()
+    if user:
+        message_context['full_name'] = user.profile.name
 
     message_context.pop('course')
     send_mandrill_email(MandrillClient.COURSE_ENROLLMENT_INVITATION, user_email, message_context)


### PR DESCRIPTION
Our course invitation email template **(COURSE_ENROLLMENT_INVITATION)** is changed, in this PR we have made changes to accommodate updated template

Files updated in this commit:

1. openedx/adg/lms/student/helpers.py: Code updated for course invitation email
2. openedx/adg/common/lib/mandrill_client/client.py: Template Id updated