### PR TITLE
LP-2489 Unit tests for education and work experience apis

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -1008,8 +1008,3 @@ urlpatterns.extend(plugin_urls.get_patterns(plugin_constants.ProjectType.LMS))
 urlpatterns += [
     url(r'^api/course_home/', include('lms.djangoapps.course_home_api.urls')),
 ]
-
-# Applications app API urls
-urlpatterns += [
-    url(r'^api/applications/', include('openedx.adg.lms.applications.api_urls', namespace='applications_api')),
-]

--- a/openedx/adg/lms/applications/api_urls.py
+++ b/openedx/adg/lms/applications/api_urls.py
@@ -1,8 +1,6 @@
 """
 All urls for applications APIs
 """
-from django.conf.urls import include
-from django.urls import path
 from rest_framework.routers import DefaultRouter
 
 from .api_views import EducationViewSet, WorkExperienceViewSet
@@ -12,6 +10,5 @@ router.register('education', EducationViewSet, basename='education')
 router.register('work_experience', WorkExperienceViewSet, basename='work_experience')
 
 app_name = 'applications'
-urlpatterns = [
-    path('', include(router.urls)),
-]
+
+urlpatterns = router.urls

--- a/openedx/adg/lms/applications/api_views.py
+++ b/openedx/adg/lms/applications/api_views.py
@@ -11,7 +11,7 @@ from .serializers import EducationSerializer, WorkExperienceSerializer
 
 
 @view_auth_classes(is_authenticated=True)
-class ApplicationRequirementsViewSetBaseClass(viewsets.ModelViewSet):
+class ApplicationRequirementsViewSet(viewsets.ModelViewSet):
     """
     Base class for user application's requirements(Education and Work Experience) apis
     """
@@ -24,10 +24,10 @@ class ApplicationRequirementsViewSetBaseClass(viewsets.ModelViewSet):
         Filter queryset to allows users to filter only their own objects.
         """
         queryset = queryset.filter(user_application__user=self.request.user)
-        return super(ApplicationRequirementsViewSetBaseClass, self).filter_queryset(queryset)
+        return super(ApplicationRequirementsViewSet, self).filter_queryset(queryset)
 
 
-class EducationViewSet(ApplicationRequirementsViewSetBaseClass):
+class EducationViewSet(ApplicationRequirementsViewSet):
     """
     ViewSet for education apis
 
@@ -73,7 +73,7 @@ class EducationViewSet(ApplicationRequirementsViewSetBaseClass):
     serializer_class = EducationSerializer
 
 
-class WorkExperienceViewSet(ApplicationRequirementsViewSetBaseClass):
+class WorkExperienceViewSet(ApplicationRequirementsViewSet):
     """
     ViewSet for work experience apis
 

--- a/openedx/adg/lms/applications/serializers.py
+++ b/openedx/adg/lms/applications/serializers.py
@@ -55,7 +55,7 @@ class EducationSerializer(serializers.ModelSerializer):
             dicts: Returns updated education attributes and errors if any in dictionary
         """
         errors = {}
-        if attrs.get('degree') == 'HD':
+        if attrs.get('degree') == Education.HIGH_SCHOOL_DIPLOMA:
             attrs['area_of_study'] = ''
         elif not attrs.get('area_of_study'):
             errors['area_of_study'] = _('Area of study is required for all degrees above High School Diploma')

--- a/openedx/adg/lms/applications/test/factories.py
+++ b/openedx/adg/lms/applications/test/factories.py
@@ -3,7 +3,7 @@ All model factories for applications
 """
 import factory
 
-from openedx.adg.lms.applications.models import ApplicationHub, BusinessLine, UserApplication
+from openedx.adg.lms.applications.models import ApplicationHub, BusinessLine, Education, UserApplication, WorkExperience
 from student.tests.factories import UserFactory
 
 
@@ -42,3 +42,39 @@ class ApplicationHubFactory(factory.DjangoModelFactory):
         django_get_or_create = ('user',)
 
     user = factory.SubFactory(UserFactory)
+
+
+class EducationFactory(factory.DjangoModelFactory):
+    """
+    Factory for Education model
+    """
+
+    class Meta:
+        model = Education
+
+    user_application = factory.SubFactory(UserApplicationFactory)
+    name_of_school = factory.Faker('word')
+    degree = Education.BACHELOR_DEGREE
+    area_of_study = factory.Faker('sentence')
+    date_started_month = 1
+    date_started_year = 2018
+    date_completed_month = 1
+    date_completed_year = 2020
+
+
+class WorkExperienceFactory(factory.DjangoModelFactory):
+    """
+    Factory for Work experience model
+    """
+
+    class Meta:
+        model = WorkExperience
+
+    user_application = factory.SubFactory(UserApplicationFactory)
+    name_of_organization = factory.Faker('word')
+    job_position_title = factory.Faker('word')
+    job_responsibilities = factory.Faker('sentence')
+    date_started_month = 1
+    date_started_year = 2018
+    date_completed_month = 1
+    date_completed_year = 2020

--- a/openedx/adg/lms/applications/test/test_api_views.py
+++ b/openedx/adg/lms/applications/test/test_api_views.py
@@ -1,0 +1,316 @@
+"""
+All tests for applications APIs views
+"""
+import json
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from student.tests.factories import UserFactory
+
+from ..models import Education, WorkExperience
+from ..serializers import EducationSerializer, WorkExperienceSerializer
+from .factories import EducationFactory, UserApplicationFactory, WorkExperienceFactory
+
+JSON_CONTENT_TYPE = 'application/json'
+
+
+# pylint: disable=redefined-outer-name, unused-argument
+
+@pytest.fixture
+def user_instance(request):
+    """
+    Create user, this fixture can be passed as a parameter to other pytests or fixtures
+    """
+    return UserFactory(password='password')
+
+
+@pytest.fixture
+def user_application(request, user_instance):
+    """
+    Create user application, this fixture can be passed as a parameter to other pytests or fixtures
+    """
+    return UserApplicationFactory(user=user_instance)
+
+
+@pytest.fixture
+def education_data(request, user_application):
+    """
+    Create education data, this fixture can be passed as a parameter to other pytests or fixtures
+    """
+    bachelor_education = EducationFactory(user_application=user_application)
+    doctoral_education = EducationFactory(user_application=user_application, degree=Education.DOCTORAL_DEGREE)
+    return bachelor_education, doctoral_education
+
+
+@pytest.fixture
+def education_data_for_post_and_patch(request, education_data):
+    """
+    Create education data, this fixture can be passed as a parameter to other pytests or fixtures
+    """
+    education, _ = education_data
+    return {
+        'date_started_month': 2,
+        'date_started_year': 2018,
+        'date_completed_month': 8,
+        'date_completed_year': 2020,
+        'name_of_school': 'PUCIT',
+        'degree': Education.BACHELOR_DEGREE,
+        'area_of_study': 'Computer Sciences',
+        'is_in_progress': False,
+        'user_application': education.user_application.id
+    }
+
+
+@pytest.fixture
+def work_experience_data(request, user_application):
+    """
+    Create work experience data, this fixture can be passed as a parameter to other pytests or fixtures
+    """
+    work_experience = WorkExperienceFactory(user_application=user_application)
+    sse_work_experience = WorkExperienceFactory(user_application=user_application, job_position_title='SSE')
+    return work_experience, sse_work_experience
+
+
+@pytest.fixture
+def work_experience_data_for_post_and_patch(request, work_experience_data):
+    """
+    Create education data, this fixture can be passed as a parameter to other pytests or fixtures
+    """
+    work_experience, _ = work_experience_data
+    return {
+        'date_started_month': 2,
+        'date_started_year': 2018,
+        'date_completed_month': 8,
+        'date_completed_year': 2020,
+        'name_of_organization': 'Arbisoft',
+        'job_position_title': 'QAE',
+        'job_responsibilities': 'Testing',
+        'is_current_position': False,
+        'user_application': work_experience.user_application.id
+    }
+
+
+@pytest.fixture
+def login_client(request, client, user_instance):
+    """
+    User login fixture. User will be authenticated for all tests where we pass this fixture.
+    """
+    client.login(username=user_instance.username, password='password')
+    return client
+
+
+@pytest.mark.django_db
+def test_unauthenticated_education_api_call(education_data, client):
+    """
+    Test education api calls for unauthenticated user.
+    """
+    url = reverse('applications_api:education-list')
+    response = client.get(url)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test_education_api_list(education_data, login_client):
+    """
+    Test education list api call for authenticated user.
+    """
+    url = reverse('applications_api:education-list')
+    response = login_client.get(url)
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data) == 2
+
+
+@pytest.mark.django_db
+def test_education_api_retrieve(education_data, login_client):
+    """
+    Test education retrieve api call for authenticated user.
+    """
+    _, expected_education_data = education_data
+    url = reverse('applications_api:education-detail', kwargs={'pk': expected_education_data.id})
+    response = login_client.get(url)
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data == EducationSerializer(expected_education_data).data
+
+
+@pytest.mark.django_db
+def test_education_api_valid_post_data(user_instance, login_client, education_data_for_post_and_patch):
+    """
+    Test education post api call with valid data for authenticated user.
+    """
+    url = reverse('applications_api:education-list')
+    response = login_client.post(
+        url, data=json.dumps(education_data_for_post_and_patch), content_type=JSON_CONTENT_TYPE
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    assert Education.objects.get(pk=response.data['id'])
+
+
+@pytest.mark.django_db
+def test_education_api_invalid_post_data(user_instance, login_client, education_data_for_post_and_patch):
+    """
+    Test education post api call with invalid data for authenticated user.
+    """
+    education_data_for_post_and_patch['is_in_progress'] = True
+    education_data_for_post_and_patch['date_completed_year'] = 2016
+
+    url = reverse('applications_api:education-list')
+    response = login_client.post(
+        url, data=json.dumps(education_data_for_post_and_patch), content_type=JSON_CONTENT_TYPE
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_education_api_valid_patch_data(education_data, login_client, education_data_for_post_and_patch):
+    """
+    Test education patch api call with valid data for authenticated user.
+    """
+    education, _ = education_data
+
+    education_data_for_post_and_patch['degree'] = Education.MASTERS_DEGREE
+    education_data_for_post_and_patch['area_of_study'] = 'Data Sciences'
+
+    url = reverse('applications_api:education-detail', kwargs={'pk': education.id})
+    response = login_client.patch(
+        url, data=json.dumps(education_data_for_post_and_patch), content_type=JSON_CONTENT_TYPE
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data['degree'] == education_data_for_post_and_patch['degree']
+    assert response.data['area_of_study'] == education_data_for_post_and_patch['area_of_study']
+
+
+@pytest.mark.django_db
+def test_education_api_invalid_patch_data(education_data, login_client, education_data_for_post_and_patch):
+    """
+    Test education patch api call with invalid data for authenticated user.
+    """
+    education, _ = education_data
+    education_data_for_post_and_patch['is_in_progress'] = True
+    url = reverse('applications_api:education-detail', kwargs={'pk': education.id})
+    response = login_client.patch(
+        url, data=json.dumps(education_data_for_post_and_patch), content_type=JSON_CONTENT_TYPE
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_education_api_delete(education_data, login_client):
+    """
+    Test education delete api call for authenticated user.
+    """
+    _, education = education_data
+    url = reverse('applications_api:education-detail', kwargs={'pk': education.id})
+    response = login_client.delete(url)
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.django_db
+def test_unauthenticated_work_experience_api_call(work_experience_data, client):
+    """
+    Test work experience api calls for unauthenticated user.
+    """
+    url = reverse('applications_api:work_experience-list')
+    response = client.get(url)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test_work_experience_api_list(work_experience_data, login_client):
+    """
+    Test work experience list api call for authenticated user.
+    """
+    url = reverse('applications_api:work_experience-list')
+    response = login_client.get(url)
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data) == 2
+
+
+@pytest.mark.django_db
+def test_work_experience_api_retrieve(work_experience_data, login_client):
+    """
+    Test work experience retrieve api call for authenticated user.
+    """
+    _, expected_work_experience_data = work_experience_data
+    url = reverse('applications_api:work_experience-detail', kwargs={'pk': expected_work_experience_data.id})
+    response = login_client.get(url)
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data == WorkExperienceSerializer(expected_work_experience_data).data
+
+
+@pytest.mark.django_db
+def test_work_experience_api_valid_post_data(user_instance, login_client, work_experience_data_for_post_and_patch):
+    """
+    Test work experience post api call with valid data for authenticated user.
+    """
+    url = reverse('applications_api:work_experience-list')
+    response = login_client.post(
+        url, data=json.dumps(work_experience_data_for_post_and_patch), content_type=JSON_CONTENT_TYPE
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    assert WorkExperience.objects.get(pk=response.data['id'])
+
+
+@pytest.mark.django_db
+def test_work_experience_api_invalid_post_data(
+    user_instance, login_client, work_experience_data_for_post_and_patch
+):
+    """
+    Test work experience post api call with invalid data for authenticated user.
+    """
+    work_experience_data_for_post_and_patch['is_current_position'] = True
+    url = reverse('applications_api:work_experience-list')
+    response = login_client.post(
+        url, data=json.dumps(work_experience_data_for_post_and_patch), content_type=JSON_CONTENT_TYPE
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_work_experience_api_valid_patch_data(
+    work_experience_data, login_client, work_experience_data_for_post_and_patch
+):
+    """
+    Test work experience patch api call with valid data for authenticated user.
+    """
+    work_experience, _ = work_experience_data
+
+    work_experience_data_for_post_and_patch['job_position_title'] = 'SSE'
+    work_experience_data_for_post_and_patch['job_responsibilities'] = 'Development'
+
+    url = reverse('applications_api:work_experience-detail', kwargs={'pk': work_experience.id})
+    response = login_client.patch(
+        url, data=json.dumps(work_experience_data_for_post_and_patch), content_type=JSON_CONTENT_TYPE
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data['job_position_title'] == work_experience_data_for_post_and_patch['job_position_title']
+    assert response.data['job_responsibilities'] == work_experience_data_for_post_and_patch['job_responsibilities']
+
+
+@pytest.mark.django_db
+def test_work_experience_api_invalid_patch_data(
+    work_experience_data, login_client, work_experience_data_for_post_and_patch
+):
+    """
+    Test work experience patch api call with invalid data for authenticated user.
+    """
+    work_experience, _ = work_experience_data
+    work_experience_data_for_post_and_patch['is_current_position'] = True
+
+    url = reverse('applications_api:work_experience-detail', kwargs={'pk': work_experience.id})
+    response = login_client.patch(
+        url, data=json.dumps(work_experience_data_for_post_and_patch), content_type=JSON_CONTENT_TYPE
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_work_experience_api_delete(work_experience_data, login_client):
+    """
+    Test work experience delete api call for authenticated user.
+    """
+    _, work_experience = work_experience_data
+    url = reverse('applications_api:work_experience-detail', kwargs={'pk': work_experience.id})
+    response = login_client.delete(url)
+    assert response.status_code == status.HTTP_204_NO_CONTENT

--- a/openedx/adg/lms/applications/test/test_helpers.py
+++ b/openedx/adg/lms/applications/test/test_helpers.py
@@ -6,9 +6,20 @@ from unittest.mock import Mock, patch
 import pytest
 
 from openedx.adg.lms.applications.constants import LOGO_IMAGE_MAX_SIZE
-from openedx.adg.lms.applications.helpers import send_application_submission_confirmation_email, validate_logo_size
+from openedx.adg.lms.applications.helpers import (
+    check_validations_for_current_record,
+    check_validations_for_past_record,
+    send_application_submission_confirmation_email,
+    validate_logo_size
+)
 
 from .constants import EMAIL
+
+DATE_COMPLETED_MONTH = 5
+DATE_COMPLETED_YEAR = 2020
+DATE_STARTED_MONTH = 2
+DATE_STARTED_YEAR = 2018
+ERROR_MESSAGE = '{key}, some error message'
 
 
 def test_validate_file_size_with_valid_size():
@@ -37,3 +48,83 @@ def test_send_application_submission_confirmation_email(mock_mandrill_email):
     """
     send_application_submission_confirmation_email(EMAIL)
     assert mock_mandrill_email.called
+
+
+@pytest.mark.parametrize('date_attrs_with_expected_results', [
+    {
+        'attrs': {},
+        'expected_result': {}
+    },
+    {
+        'attrs': {'date_completed_month': DATE_COMPLETED_MONTH},
+        'expected_result': {'date_completed_month': ERROR_MESSAGE.format(key='Date completed month')}
+    },
+    {
+        'attrs': {'date_completed_year': DATE_COMPLETED_YEAR},
+        'expected_result': {'date_completed_year': ERROR_MESSAGE.format(key='Date completed year')}
+    },
+    {
+        'attrs': {'date_completed_month': DATE_COMPLETED_MONTH, 'date_completed_year': DATE_COMPLETED_YEAR},
+        'expected_result': {
+            'date_completed_month': ERROR_MESSAGE.format(key='Date completed month'),
+            'date_completed_year': ERROR_MESSAGE.format(key='Date completed year')
+        }
+    },
+])
+def test_check_validations_for_current_record(date_attrs_with_expected_results):
+    """
+    Check for expected validation errors against provided data
+    """
+    actual_result = check_validations_for_current_record(date_attrs_with_expected_results['attrs'], ERROR_MESSAGE)
+    assert actual_result == date_attrs_with_expected_results['expected_result']
+
+
+@pytest.mark.parametrize('date_attrs_with_expected_results', [
+    {
+        'attrs': {'date_started_month': DATE_COMPLETED_MONTH, 'date_started_year': DATE_COMPLETED_YEAR},
+        'expected_result': {
+            'date_completed_month': ERROR_MESSAGE.format(key='Date completed month'),
+            'date_completed_year': ERROR_MESSAGE.format(key='Date completed year')
+        }
+    },
+    {
+        'attrs': {
+            'date_completed_month': DATE_COMPLETED_MONTH,
+            'date_started_month': DATE_STARTED_MONTH,
+            'date_started_year': DATE_STARTED_YEAR
+        },
+        'expected_result': {'date_completed_year': ERROR_MESSAGE.format(key='Date completed year')}
+    },
+    {
+        'attrs': {
+            'date_completed_year': DATE_COMPLETED_YEAR,
+            'date_started_month': DATE_STARTED_MONTH,
+            'date_started_year': DATE_STARTED_YEAR
+        },
+        'expected_result': {'date_completed_month': ERROR_MESSAGE.format(key='Date completed month')}
+    },
+    {
+        'attrs': {
+            'date_completed_month': DATE_COMPLETED_MONTH,
+            'date_completed_year': DATE_COMPLETED_YEAR,
+            'date_started_month': DATE_STARTED_MONTH,
+            'date_started_year': DATE_STARTED_YEAR
+        },
+        'expected_result': {}
+    },
+    {
+        'attrs': {
+            'date_completed_month': DATE_COMPLETED_MONTH,
+            'date_completed_year': DATE_COMPLETED_YEAR,
+            'date_started_month': DATE_STARTED_MONTH,
+            'date_started_year': DATE_COMPLETED_YEAR + 1
+        },
+        'expected_result': {'date_completed_year': 'Completion date must comes after started date'}
+    }
+])
+def test_check_validations_for_past_record(date_attrs_with_expected_results):
+    """
+    Check for expected validation errors against provided data
+    """
+    actual_result = check_validations_for_past_record(date_attrs_with_expected_results['attrs'], ERROR_MESSAGE)
+    assert actual_result == date_attrs_with_expected_results['expected_result']

--- a/openedx/adg/lms/applications/test/test_serializers.py
+++ b/openedx/adg/lms/applications/test/test_serializers.py
@@ -1,0 +1,140 @@
+"""
+All tests for applications APIs serializers
+"""
+import pytest
+
+from student.tests.factories import UserFactory
+
+from ..models import Education
+from ..serializers import EducationSerializer, WorkExperienceSerializer
+from .factories import UserApplicationFactory
+
+
+@pytest.fixture
+def user_application(request):
+    """
+    Create user application, this fixture can be passed as a parameter to other pytests or fixtures
+    """
+    return UserApplicationFactory(user=UserFactory())
+
+
+@pytest.fixture
+def education_data(request, user_application):  # pylint: disable=redefined-outer-name
+    """
+    Data for education serializer
+    """
+    return {
+        'date_started_month': 2,
+        'date_started_year': 2017,
+        'date_completed_month': 3,
+        'date_completed_year': 2018,
+        'name_of_school': 'PUCIT',
+        'degree': Education.BACHELOR_DEGREE,
+        'is_in_progress': True,
+        'user_application': user_application.id
+    }
+
+
+@pytest.fixture
+def work_experience_data(request, user_application):  # pylint: disable=redefined-outer-name
+    """
+    Data for education serializer
+    """
+    return {
+        'date_started_month': 2,
+        'date_started_year': 2018,
+        'date_completed_month': 8,
+        'date_completed_year': 2020,
+        'name_of_organization': 'Arbisoft',
+        'job_position_title': 'SSE',
+        'is_current_position': True,
+        'job_responsibilities': 'Testing',
+        'user_application': user_application.id
+    }
+
+
+@pytest.mark.django_db
+def test_education_serializer_with_invalid_data(education_data):  # pylint: disable=redefined-outer-name
+    """
+    Verify the education serializer behavior for invalid data.
+    """
+    expected_errors = {
+        'date_completed_year': [
+            'Date completed year isn\'t applicable for degree in progress'
+        ],
+        'date_completed_month': [
+            'Date completed month isn\'t applicable for degree in progress'
+        ],
+        'area_of_study': [
+            'Area of study is required for all degrees above High School Diploma'
+        ]
+    }
+    serializer = EducationSerializer(data=education_data)
+
+    assert not serializer.is_valid()
+    assert serializer.errors == expected_errors
+
+
+@pytest.mark.django_db
+def test_education_serializer_with_valid_data(education_data):  # pylint: disable=redefined-outer-name
+    """
+    Verify the education serializer behavior for valid data.
+    """
+    education_data['is_in_progress'] = False
+    education_data['area_of_study'] = 'Computer Sciences'
+
+    serializer = EducationSerializer(data=education_data)
+
+    assert serializer.is_valid()
+    assert not serializer.errors
+
+
+@pytest.mark.django_db
+def test_education_serializer_with_valid_degree_data(education_data):  # pylint: disable=redefined-outer-name
+    """
+    Verify the education serializer behavior for different degree values
+    """
+    education_data['is_in_progress'] = False
+    education_data['area_of_study'] = 'Computer Sciences'
+    serializer = EducationSerializer(data=education_data)
+
+    assert serializer.is_valid()
+    assert not serializer.errors
+    assert serializer.data['area_of_study'] == 'Computer Sciences'
+
+    education_data['degree'] = Education.HIGH_SCHOOL_DIPLOMA
+    serializer = EducationSerializer(data=education_data)
+
+    assert serializer.is_valid()
+    assert not serializer.data['area_of_study']
+
+
+@pytest.mark.django_db
+def test_work_experience_serializer_with_invalid_data(work_experience_data):  # pylint: disable=redefined-outer-name
+    """
+    Verify the work experience serializer behavior for invalid data.
+    """
+    expected_errors = {
+        'date_completed_year': [
+            'Date completed year isn\'t applicable for current work experience'
+        ],
+        'date_completed_month': [
+            'Date completed month isn\'t applicable for current work experience'
+        ]
+    }
+    serializer = WorkExperienceSerializer(data=work_experience_data)
+
+    assert not serializer.is_valid()
+    assert serializer.errors == expected_errors
+
+
+@pytest.mark.django_db
+def test_work_experience_serializer_with_valid_data(work_experience_data):  # pylint: disable=redefined-outer-name
+    """
+    Verify the work experience serializer behavior for valid data.
+    """
+    work_experience_data['is_current_position'] = False
+    serializer = WorkExperienceSerializer(data=work_experience_data)
+
+    assert serializer.is_valid()
+    assert not serializer.errors

--- a/openedx/adg/lms/urls.py
+++ b/openedx/adg/lms/urls.py
@@ -1,3 +1,6 @@
+"""
+Urls for adg apps
+"""
 from django.conf.urls import include, url
 
 adg_url_patterns = [
@@ -6,5 +9,9 @@ adg_url_patterns = [
     url(
         r'^application/',
         include('openedx.adg.lms.applications.urls'),
+    ),
+    url(
+        r'^api/applications/',
+        include('openedx.adg.lms.applications.api_urls', namespace='applications_api')
     ),
 ]


### PR DESCRIPTION
Unit test for education and work experience apis related to [LP-2460](https://philanthropyu.atlassian.net/browse/LP-2489)
Tests related code are in **openedx/adg/lms/applications/test/** directory
Few changes in this commit related to education and work experience apis and not related to tests. Those are the suggestions from @ahmed-faraz46 from following PRs.
- Add swagger documentation for education and work experience apis, [PR](https://github.com/OmnipreneurshipAcademy/edx-platform/pull/86)
- Write Required APIs for application page 2, [PR](https://github.com/OmnipreneurshipAcademy/edx-platform/pull/88
) 