### PR TITLE
lp-2518 fix pylint configuration

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -61,7 +61,7 @@ jobs:
         id: pylint-report
         continue-on-error: true
         run: |
-          pylint ${{ env.GIT_DIFF }} 2>&1 | tee report_pylint.txt
+          pylint --score=y ${{ env.GIT_DIFF }} 2>&1 | tee report_pylint.txt
 
           body=$(cat report_pylint.txt)
           body="${body//'%'/'%25'}"


### PR DESCRIPTION
After koa-upgrade, edx-lint version has been upgraded too from 1.4.1 to 1.5.2. In this version **score = no** has been added in Report setting mentioned in file **pylintrc**