### PR TITLE
Fix get_user_first_name by getting name instead of full_name

### DIFF
--- a/openedx/adg/common/lib/mandrill_client/client.py
+++ b/openedx/adg/common/lib/mandrill_client/client.py
@@ -23,7 +23,7 @@ class MandrillClient(object):
     VERIFY_CHANGE_USER_EMAIL = 'adg-verify-email-address-change-step-2'
     APPLICATION_SUBMISSION_CONFIRMATION = 'adg-application-submission-confirmation-1'
     APPLICATION_WAITLISTED = 'adg-waitlisted-application'
-    APPLICATION_ACCEPTED = 'adg-accepted-application-professional-and-forma'
+    APPLICATION_ACCEPTED = 'adg-application-accepted'
 
     def __init__(self):
         self.mandrill_client = mandrill.Mandrill(settings.MANDRILL_API_KEY)

--- a/openedx/adg/lms/helpers.py
+++ b/openedx/adg/lms/helpers.py
@@ -13,4 +13,4 @@ def get_user_first_name(user):
         (str) first name of the user
 
     """
-    return user.first_name or user.profile.full_name.split()[0]
+    return user.first_name or user.profile.name.split()[0]

--- a/openedx/adg/lms/tests/__init__.py
+++ b/openedx/adg/lms/tests/__init__.py
@@ -1,0 +1,1 @@
+""" Tests for ADG LMS """

--- a/openedx/adg/lms/tests/constants.py
+++ b/openedx/adg/lms/tests/constants.py
@@ -1,0 +1,3 @@
+""" Constants for ADG LMS tests """
+FIRST_NAME = 'test_first_name'
+FIRST_PART_OF_FULL_NAME = 'Test'

--- a/openedx/adg/lms/tests/test_helpers.py
+++ b/openedx/adg/lms/tests/test_helpers.py
@@ -1,0 +1,25 @@
+""" Tests for LMS helper """
+import pytest
+
+from common.djangoapps.student.tests.factories import UserFactory, UserProfileFactory
+from openedx.adg.lms.helpers import get_user_first_name
+
+from .constants import FIRST_NAME, FIRST_PART_OF_FULL_NAME
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'first_name, full_name, expected_first_name', [
+        (FIRST_NAME, '', FIRST_NAME),
+        ('', f'{FIRST_PART_OF_FULL_NAME} last_part_of_full_name', FIRST_PART_OF_FULL_NAME)
+    ],
+    ids=['user_with_first_name', 'user_with_full_name']
+)
+def test_get_user_first_name(first_name, full_name, expected_first_name):
+    """
+    Tests `get_user_first_name` helper
+    """
+    user = UserFactory(first_name=first_name)
+    UserProfileFactory(user=user, name=full_name)
+
+    assert get_user_first_name(user) == expected_first_name


### PR DESCRIPTION
A fix in [LP-2479](https://philanthropyu.atlassian.net/browse/LP-2479), [LP-2565](https://philanthropyu.atlassian.net/browse/LP-2565)
- Rename accepted email template slug
- Add unit tests for lms helpers