### PR TITLE
LP-2478 Dont allow future dates in education and experience API

### DIFF
--- a/openedx/adg/lms/applications/api_views.py
+++ b/openedx/adg/lms/applications/api_views.py
@@ -23,7 +23,7 @@ class ApplicationRequirementsViewSet(viewsets.ModelViewSet):
     """
     filter_backends = (DjangoFilterBackend,)
     pagination_class = None
-    http_method_names = ['get', 'post', 'head', 'patch', 'delete']
+    http_method_names = ['get', 'post', 'head', 'put', 'patch', 'delete']
 
     def filter_queryset(self, queryset):
         """
@@ -68,11 +68,11 @@ class EducationViewSet(ApplicationRequirementsViewSet):
     **Example Requests**
     DELETE /api/applications/education/
 
-    partial_update:
+    update:
         Update an existing education record.
 
     **Example Requests**
-    PATCH /api/applications/education/
+    PUT /api/applications/education/
 
     """
     queryset = Education.objects.all()
@@ -113,12 +113,16 @@ class WorkExperienceViewSet(ApplicationRequirementsViewSet):
     **Example Requests**
     DELETE /api/applications/work_experience/
 
-    partial_update:
+    update:
         Update an existing work experience record.
+
+    **Example Requests**
+    PUT /api/applications/work_experience/
+
+    partial_update:
         Update user work_experience is not applicable
 
     **Example Requests**
-    PATCH /api/applications/work_experience/
     PATCH /api/applications/work_experience/update_is_not_applicable/
 
     """

--- a/openedx/adg/lms/applications/helpers.py
+++ b/openedx/adg/lms/applications/helpers.py
@@ -55,19 +55,22 @@ def check_validations_for_past_record(attrs, error_message):
     """
     errors = {}
 
+    started_date = datetime(year=attrs['date_started_year'], month=attrs['date_started_month'], day=1)
+    errors = update_errors_if_future_date(started_date, errors, 'date_started_year')
+
     if not attrs.get('date_completed_month', False):
         errors['date_completed_month'] = _(error_message).format(key='Date completed month')
 
     if not attrs.get('date_completed_year', False):
         errors['date_completed_year'] = _(error_message).format(key='Date completed year')
 
-    started_date = datetime(year=attrs['date_started_year'], month=attrs['date_started_month'], day=1)
-
     if attrs.get('date_completed_month') and attrs.get('date_completed_year'):
         completed_date = datetime(year=attrs['date_completed_year'], month=attrs['date_completed_month'], day=1)
 
         if completed_date <= started_date:
             errors['date_completed_year'] = _('Completion date must comes after started date')
+
+        errors = update_errors_if_future_date(completed_date, errors, 'date_completed_year')
 
     return errors
 
@@ -85,11 +88,27 @@ def check_validations_for_current_record(attrs, error_message):
     """
     errors = {}
 
+    started_date = datetime(year=attrs['date_started_year'], month=attrs['date_started_month'], day=1)
+    errors = update_errors_if_future_date(started_date, errors, 'date_started_year')
+
     if attrs.get('date_completed_month'):
         errors['date_completed_month'] = _(error_message).format(key='Date completed month')
 
     if attrs.get('date_completed_year'):
         errors['date_completed_year'] = _(error_message).format(key='Date completed year')
+
+    return errors
+
+
+def update_errors_if_future_date(date, errors, key):
+    """
+    Update errors dict if date is in future
+
+    Returns:
+        dict: contains updated error messages
+    """
+    if datetime.now() <= date:
+        errors[key] = _('Date should not be in future')
 
     return errors
 

--- a/openedx/adg/lms/applications/helpers.py
+++ b/openedx/adg/lms/applications/helpers.py
@@ -104,6 +104,11 @@ def update_errors_if_future_date(date, errors, key):
     """
     Update errors dict if date is in future
 
+    Arguments:
+        date (datetime): date that needs to be checked
+        errors (dict): error messages dict that needs to be updated
+        key (str): field key for adding error
+
     Returns:
         dict: contains updated error messages
     """

--- a/openedx/adg/lms/applications/helpers.py
+++ b/openedx/adg/lms/applications/helpers.py
@@ -68,7 +68,7 @@ def check_validations_for_past_record(attrs, error_message):
         completed_date = datetime(year=attrs['date_completed_year'], month=attrs['date_completed_month'], day=1)
 
         if completed_date <= started_date:
-            errors['date_completed_year'] = _('Completion date must comes after started date')
+            errors['date_completed_year'] = _('Completed date must be greater than started date.')
 
         errors = update_errors_if_future_date(completed_date, errors, 'date_completed_year')
 

--- a/openedx/adg/lms/applications/tests/test_helpers.py
+++ b/openedx/adg/lms/applications/tests/test_helpers.py
@@ -197,7 +197,7 @@ def test_check_validations_for_current_record(date_attrs_with_expected_results):
             'date_started_month': DATE_STARTED_MONTH,
             'date_started_year': DATE_COMPLETED_YEAR + 1
         },
-        'expected_result': {'date_completed_year': 'Completion date must comes after started date'}
+        'expected_result': {'date_completed_year': 'Completed date must be greater than started date.'}
     }
 ])
 def test_check_validations_for_past_record(date_attrs_with_expected_results):

--- a/openedx/adg/lms/applications/tests/test_helpers.py
+++ b/openedx/adg/lms/applications/tests/test_helpers.py
@@ -109,22 +109,43 @@ def test_max_year_value_validator_valid():
 
 @pytest.mark.parametrize('date_attrs_with_expected_results', [
     {
-        'attrs': {},
+        'attrs': {
+            'date_started_month': 1,
+            'date_started_year': date.today().year - 1,
+        },
         'expected_result': {}
     },
     {
-        'attrs': {'date_completed_month': DATE_COMPLETED_MONTH},
-        'expected_result': {'date_completed_month': ERROR_MESSAGE.format(key='Date completed month')}
+        'attrs': {
+            'date_started_month': 1,
+            'date_started_year': date.today().year - 1,
+            'date_completed_month': DATE_COMPLETED_MONTH
+        },
+        'expected_result': {
+            'date_completed_month': ERROR_MESSAGE.format(key='Date completed month')
+        }
     },
     {
-        'attrs': {'date_completed_year': DATE_COMPLETED_YEAR},
-        'expected_result': {'date_completed_year': ERROR_MESSAGE.format(key='Date completed year')}
+        'attrs': {
+            'date_started_month': 1,
+            'date_started_year': date.today().year - 1,
+            'date_completed_year': DATE_COMPLETED_YEAR
+        },
+        'expected_result': {
+            'date_completed_year': ERROR_MESSAGE.format(key='Date completed year')
+        }
     },
     {
-        'attrs': {'date_completed_month': DATE_COMPLETED_MONTH, 'date_completed_year': DATE_COMPLETED_YEAR},
+        'attrs': {
+            'date_started_month': 1,
+            'date_started_year': date.today().year + 1,
+            'date_completed_month': DATE_COMPLETED_MONTH,
+            'date_completed_year': DATE_COMPLETED_YEAR,
+        },
         'expected_result': {
             'date_completed_month': ERROR_MESSAGE.format(key='Date completed month'),
-            'date_completed_year': ERROR_MESSAGE.format(key='Date completed year')
+            'date_completed_year': ERROR_MESSAGE.format(key='Date completed year'),
+            'date_started_year': 'Date should not be in future',
         }
     },
 ])


### PR DESCRIPTION
[LP-2478](https://philanthropyu.atlassian.net/browse/LP-2478)
[adg-edx-theme](https://github.com/OmnipreneurshipAcademy/adg-edx-theme/pull/138)

- Update education and work experience APIs to validate that user should not be able to select future dates.
- I also allow put method to resolve a bug in APIs to update education and experience records