### PR TITLE
LP-2585 Export philu personal access token in environment

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -44,6 +44,8 @@ jobs:
         if: env.GIT_DIFF
 
       - name: Install requirements
+        env:
+          PHILU_PAT: ${{ secrets.PHILU_PAT }}
         run: |
           sudo apt-get install libxmlsec1-dev pkg-config
           sudo apt-get update


### PR DESCRIPTION
[LP-2585](https://philanthropyu.atlassian.net/browse/LP-2585)
- Export philu personal access token in environment
NOTE: For CircleCI workflow, PHILU_PAT is exported in environment, from the app, so no code change was required, Right now pipelines might post that no python file detected, but I've tested it with some temporary changes and reverted those changes, attaching screen shots of successful runs
<img width="855" alt="Screen Shot 2021-03-18 at 10 25 56 PM" src="https://user-images.githubusercontent.com/29256866/111671386-b6b92600-883a-11eb-8519-7c3b008212bd.png">


