### PR TITLE
Change contact url to /contact

### DIFF
--- a/openedx/adg/lms/branding_extension/helpers.py
+++ b/openedx/adg/lms/branding_extension/helpers.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.utils.translation import ugettext as _
 
 from common.djangoapps.edxmako.shortcuts import marketing_link
-from lms.djangoapps.branding.api import _build_support_form_url
 from openedx.adg.lms.utils.env_utils import is_testing_environment
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
@@ -24,7 +23,7 @@ def get_footer_navigation_links():
         (marketing_link('ABOUT'), _('About')),
         (marketing_link('OUR_TEAM'), _('Our Team')),
         (marketing_link('TOS'), _('Terms')),
-        (_build_support_form_url(), _('Contact')),
+        (marketing_link('CONTACT'), _('Contact')),
     ]
 
     return [

--- a/openedx/adg/lms/branding_extension/tests/helpers_tests.py
+++ b/openedx/adg/lms/branding_extension/tests/helpers_tests.py
@@ -18,9 +18,7 @@ def test_get_footer_navigation_links(mocker):
     Tests `get_footer_navigation_links` helper method of branding extension
     """
     test_url = 'test_url'
-    test_support_url = 'test_support_url'
     mocker.patch('openedx.adg.lms.branding_extension.helpers.marketing_link', return_value=test_url)
-    mocker.patch('openedx.adg.lms.branding_extension.helpers._build_support_form_url', return_value=test_support_url)
 
     branding_links = get_footer_navigation_links()
     assert len(branding_links) == 4
@@ -38,7 +36,7 @@ def test_get_footer_navigation_links(mocker):
             'title': 'Terms',
         },
         {
-            'url': test_support_url,
+            'url': test_url,
             'title': 'Contact',
         },
     ]


### PR DESCRIPTION
[LP-2603](https://philanthropyu.atlassian.net/browse/LP-2603)
Previously contact in the footer was linked to a support link, as we have a different requirement for static contact page, so we have change the link accordingly.