### PR TITLE
LP-2630 - Add mandrill support for multiple emails

### DIFF
--- a/openedx/adg/common/lib/mandrill_client/client.py
+++ b/openedx/adg/common/lib/mandrill_client/client.py
@@ -7,7 +7,6 @@ import mandrill
 from django.conf import settings
 
 from .email_data import EmailData
-from .helpers import add_user_preferred_language_to_template_slug
 
 log = logging.getLogger(__name__)
 
@@ -57,20 +56,18 @@ class MandrillClient(object):
             raise
         return result
 
-    def send_mandrill_email(self, template, email, context):
+    def send_mandrill_email(self, template, emails, context):
         """
         Creates EmailData object and calls _send_email
 
         Arguments:
             template (str): String containing template id
-            email (str): Email address of user
+            emails (list): Email addresses of recipient users
             context (dict): Dictionary containing email content
 
         Returns:
             None
         """
-        log.info(f'Sending email using template: {template}, account: {email} and context: {context} using mandrill')
-
-        template = add_user_preferred_language_to_template_slug(template, email)
-        email_data = EmailData(template, email, context)
+        log.info(f'Sending email using template: {template}, account: {emails} and context: {context} using mandrill')
+        email_data = EmailData(template, emails, context)
         self._send_mail(email_data)

--- a/openedx/adg/common/lib/mandrill_client/email_data.py
+++ b/openedx/adg/common/lib/mandrill_client/email_data.py
@@ -10,13 +10,13 @@ class EmailData(object):
     Email data class that contains all data related to email
     """
 
-    def __init__(self, template_name, user_email, context, subject=None, attachments=None):
+    def __init__(self, template_name, recipient_emails, context, subject=None, attachments=None):
         self.template_name = template_name
         global_merge_vars = [{'name': key, 'content': context[key]} for key in context]
 
         self.message = {
             'from_email': settings.NOTIFICATION_FROM_EMAIL,
-            'to': [{'email': user_email}],
+            'to': recipient_emails,
             'global_merge_vars': global_merge_vars,
             'attachments': attachments or [],
         }

--- a/openedx/adg/common/lib/mandrill_client/tasks.py
+++ b/openedx/adg/common/lib/mandrill_client/tasks.py
@@ -5,24 +5,35 @@ import logging
 
 from celery.task import task
 
+from openedx.adg.common.lib.mandrill_client.helpers import add_user_preferred_language_to_template_slug
+
 from .client import MandrillClient
 
 log = logging.getLogger(__name__)
 
 
 @task()
-def task_send_mandrill_email(template, email, context):
+def task_send_mandrill_email(template, emails, context):
     """
     Sends an email by calling send_mandrill_email, asynchronously
 
     Arguments:
         template (str): String containing template id
-        email (str): Email address of user
+        emails (iterable): Email addresses of users
         context (dict): Dictionary containing email content
 
     Returns:
         None
     """
-    log.info(f'Sending an email using template: {template} to account: {email}, from inside task_send_mandrill_email')
+    log.info(f'Sending an email using template: {template} to accounts: {emails}, from inside task_send_mandrill_email')
 
-    MandrillClient().send_mandrill_email(template, email, context)
+    template_to_email_adresses_map = {}
+    for email in emails:
+        template_slug = add_user_preferred_language_to_template_slug(template, email)
+        if template_to_email_adresses_map.get(template_slug, None):
+            template_to_email_adresses_map[template_slug].append({'email': email})
+        else:
+            template_to_email_adresses_map[template_slug] = [{'email': email}]
+
+    for template_slug, recipient_emails in template_to_email_adresses_map.items():
+        MandrillClient().send_mandrill_email(template_slug, recipient_emails, context)

--- a/openedx/adg/common/lib/mandrill_client/tasks.py
+++ b/openedx/adg/common/lib/mandrill_client/tasks.py
@@ -2,6 +2,7 @@
 Tasks for Mandrill client
 """
 import logging
+from collections import defaultdict
 
 from celery.task import task
 
@@ -27,13 +28,10 @@ def task_send_mandrill_email(template, emails, context):
     """
     log.info(f'Sending an email using template: {template} to accounts: {emails}, from inside task_send_mandrill_email')
 
-    template_to_email_adresses_map = {}
+    template_to_email_adresses_map = defaultdict(list)
     for email in emails:
         template_slug = add_user_preferred_language_to_template_slug(template, email)
-        if template_to_email_adresses_map.get(template_slug, None):
-            template_to_email_adresses_map[template_slug].append({'email': email})
-        else:
-            template_to_email_adresses_map[template_slug] = [{'email': email}]
+        template_to_email_adresses_map[template_slug].append({'email': email})
 
     for template_slug, recipient_emails in template_to_email_adresses_map.items():
         MandrillClient().send_mandrill_email(template_slug, recipient_emails, context)

--- a/openedx/adg/common/lib/mandrill_client/tests/test_tasks.py
+++ b/openedx/adg/common/lib/mandrill_client/tests/test_tasks.py
@@ -10,7 +10,9 @@ from openedx.adg.common.lib.mandrill_client.tasks import task_send_mandrill_emai
 
 @pytest.mark.django_db
 @patch('openedx.adg.common.lib.mandrill_client.tasks.MandrillClient')
-def test_task_send_mandrill_email(mock_mandrill_client):
-    task_send_mandrill_email('email_template', ['user@email.com'], {'content': 'content'})
-
+@pytest.mark.parametrize(
+    'email_addresses', [['user1@email.com'], ['user1@email.com', 'user2@email.com']]
+)
+def test_task_send_mandrill_email(mock_mandrill_client, email_addresses):
+    task_send_mandrill_email('email_template', email_addresses, {'content': 'content'})
     mock_mandrill_client.assert_called_once()

--- a/openedx/adg/common/lib/mandrill_client/tests/test_tasks.py
+++ b/openedx/adg/common/lib/mandrill_client/tests/test_tasks.py
@@ -3,11 +3,14 @@ All tests for mandrill client tasks
 """
 from unittest.mock import patch
 
+import pytest
+
 from openedx.adg.common.lib.mandrill_client.tasks import task_send_mandrill_email
 
 
+@pytest.mark.django_db
 @patch('openedx.adg.common.lib.mandrill_client.tasks.MandrillClient')
 def test_task_send_mandrill_email(mock_mandrill_client):
-    task_send_mandrill_email('email_template', 'user@email.com', {'content': 'content'})
+    task_send_mandrill_email('email_template', ['user@email.com'], {'content': 'content'})
 
     mock_mandrill_client.assert_called_once()

--- a/openedx/adg/lms/applications/admin.py
+++ b/openedx/adg/lms/applications/admin.py
@@ -405,7 +405,7 @@ class UserApplicationADGAdmin(admin.ModelAdmin):
         }
 
         task_send_mandrill_email.delay(
-            status_email_template_map[application.status], applicant.email, email_context
+            status_email_template_map[application.status], [applicant.email], email_context
         )
 
     def email(self, obj):

--- a/openedx/adg/lms/applications/helpers.py
+++ b/openedx/adg/lms/applications/helpers.py
@@ -135,7 +135,7 @@ def send_application_submission_confirmation_email(recipient_email):
     context = {
         'course_catalog_url': course_catalog_url
     }
-    task_send_mandrill_email.delay(MandrillClient.APPLICATION_SUBMISSION_CONFIRMATION, recipient_email, context)
+    task_send_mandrill_email.delay(MandrillClient.APPLICATION_SUBMISSION_CONFIRMATION, [recipient_email], context)
 
 
 def min_year_value_validator(value):

--- a/openedx/adg/lms/applications/tests/test_admin/test_user_application_adg_admin.py
+++ b/openedx/adg/lms/applications/tests/test_admin/test_user_application_adg_admin.py
@@ -285,7 +285,7 @@ def test_send_application_status_update_email(
 
     UserApplicationADGAdmin._send_application_status_update_email('self', user_application, TEST_MESSAGE_FOR_APPLICANT)
     mock_send_mandrill_email.delay.assert_called_once_with(
-        expected_email_template, user_application.user.email, expected_email_context
+        expected_email_template, [user_application.user.email], expected_email_context
     )
 
 

--- a/openedx/adg/lms/student/helpers.py
+++ b/openedx/adg/lms/student/helpers.py
@@ -37,7 +37,7 @@ def compose_and_send_adg_activation_email(user, activation_key):
         'activation_link': activation_url
     }
 
-    task_send_mandrill_email(MandrillClient.USER_ACCOUNT_ACTIVATION, user.email, context)
+    task_send_mandrill_email(MandrillClient.USER_ACCOUNT_ACTIVATION, [user.email], context)
 
 
 def compose_and_send_adg_password_reset_email(user, request):
@@ -65,7 +65,7 @@ def compose_and_send_adg_password_reset_email(user, request):
         'reset_link': reset_link
     }
 
-    task_send_mandrill_email(MandrillClient.PASSWORD_RESET, user.email, context)
+    task_send_mandrill_email(MandrillClient.PASSWORD_RESET, [user.email], context)
 
 
 def compose_and_send_adg_update_email_verification(user, use_https, confirm_link):
@@ -90,7 +90,7 @@ def compose_and_send_adg_update_email_verification(user, use_https, confirm_link
         'update_email_link': update_email_link
     }
 
-    task_send_mandrill_email(MandrillClient.CHANGE_USER_EMAIL_ALERT, user.email, context)
+    task_send_mandrill_email(MandrillClient.CHANGE_USER_EMAIL_ALERT, [user.email], context)
 
 
 def compose_and_send_adg_update_email_confirmation(user, context):
@@ -104,7 +104,7 @@ def compose_and_send_adg_update_email_confirmation(user, context):
     Returns:
         None
     """
-    task_send_mandrill_email(MandrillClient.VERIFY_CHANGE_USER_EMAIL, user.email, context)
+    task_send_mandrill_email(MandrillClient.VERIFY_CHANGE_USER_EMAIL, [user.email], context)
 
 
 def compose_and_send_adg_course_enrollment_confirmation_email(user, course_id):
@@ -129,7 +129,7 @@ def compose_and_send_adg_course_enrollment_confirmation_email(user, course_id):
         'course_name': course.display_name,
         'course_url': course_url
     }
-    task_send_mandrill_email.delay(MandrillClient.ENROLLMENT_CONFIRMATION, user.email, context)
+    task_send_mandrill_email.delay(MandrillClient.ENROLLMENT_CONFIRMATION, [user.email], context)
 
 
 def compose_and_send_adg_course_enrollment_invitation_email(user_email, message_context):
@@ -153,4 +153,4 @@ def compose_and_send_adg_course_enrollment_invitation_email(user_email, message_
         message_context['full_name'] = user.profile.name
 
     message_context.pop('course')
-    task_send_mandrill_email.delay(MandrillClient.COURSE_ENROLLMENT_INVITATION, user_email, message_context)
+    task_send_mandrill_email.delay(MandrillClient.COURSE_ENROLLMENT_INVITATION, [user_email], message_context)

--- a/openedx/adg/lms/student/tests/test_helpers.py
+++ b/openedx/adg/lms/student/tests/test_helpers.py
@@ -54,7 +54,7 @@ def test_compose_and_send_adg_activation_email(
 
     student_helpers.compose_and_send_adg_activation_email(user_with_profile, activation_key)
     mock_task_send_mandrill_email.assert_called_once_with(
-        mock_mandrill_client.USER_ACCOUNT_ACTIVATION, user_with_profile.email, expected_context
+        mock_mandrill_client.USER_ACCOUNT_ACTIVATION, [user_with_profile.email], expected_context
     )
 
 
@@ -87,7 +87,7 @@ def test_compose_and_send_adg_password_reset_email(
 
     student_helpers.compose_and_send_adg_password_reset_email(user_with_profile, fake_request)
     mock_task_send_mandrill_email.assert_called_once_with(
-        mock_mandrill_client.PASSWORD_RESET, user_with_profile.email, expected_context
+        mock_mandrill_client.PASSWORD_RESET, [user_with_profile.email], expected_context
     )
 
 
@@ -112,7 +112,7 @@ def test_compose_and_send_adg_update_email_verification(
 
     student_helpers.compose_and_send_adg_update_email_verification(user_with_profile, True, confirmation_link)
     mock_task_send_mandrill_email.assert_called_once_with(
-        mock_mandrill_client.CHANGE_USER_EMAIL_ALERT, user_with_profile.email, expected_context
+        mock_mandrill_client.CHANGE_USER_EMAIL_ALERT, [user_with_profile.email], expected_context
     )
 
 
@@ -129,7 +129,7 @@ def test_compose_and_send_adg_update_email_confirmation(
 
     student_helpers.compose_and_send_adg_update_email_confirmation(user_with_profile, context)
     mock_task_send_mandrill_email.assert_called_once_with(
-        mock_mandrill_client.VERIFY_CHANGE_USER_EMAIL, user_with_profile.email, context
+        mock_mandrill_client.VERIFY_CHANGE_USER_EMAIL, [user_with_profile.email], context
     )
 
 
@@ -172,7 +172,7 @@ class MandrillCourseEnrollmentEmails(ModuleStoreTestCase):
         }
         student_helpers.compose_and_send_adg_course_enrollment_confirmation_email(self.user, self.course.id)
         mock_task_send_mandrill_email.delay.assert_called_once_with(
-            mock_mandrill_client.ENROLLMENT_CONFIRMATION, self.user.email, expected_context
+            mock_mandrill_client.ENROLLMENT_CONFIRMATION, [self.user.email], expected_context
         )
 
     @patch('openedx.adg.lms.student.helpers.task_send_mandrill_email')
@@ -194,7 +194,7 @@ class MandrillCourseEnrollmentEmails(ModuleStoreTestCase):
             self.user.email, {'display_name': self.course.display_name, 'course': 'dummy_obj'}
         )
         mock_task_send_mandrill_email.delay.assert_called_once_with(
-            mock_mandrill_client.COURSE_ENROLLMENT_INVITATION, self.user.email, expected_context
+            mock_mandrill_client.COURSE_ENROLLMENT_INVITATION, [self.user.email], expected_context
         )
 
     @patch('openedx.adg.lms.student.helpers.task_send_mandrill_email')
@@ -215,5 +215,5 @@ class MandrillCourseEnrollmentEmails(ModuleStoreTestCase):
             self.user.email, {'course': self.course}
         )
         mock_task_send_mandrill_email.delay.assert_called_once_with(
-            mock_mandrill_client.COURSE_ENROLLMENT_INVITATION, self.user.email, expected_context
+            mock_mandrill_client.COURSE_ENROLLMENT_INVITATION, [self.user.email], expected_context
         )


### PR DESCRIPTION
[LP-2630](https://philanthropyu.atlassian.net/browse/LP-2630)

- Add mandrill support for a group of email addresses to send the email to.
- Change all the occurrences of the send email task to conform with the new changes.