### PR TITLE
LP-2629 Customise interface for webinar for admins

### DIFF
--- a/openedx/adg/lms/webinars/admin.py
+++ b/openedx/adg/lms/webinars/admin.py
@@ -19,6 +19,7 @@ class WebinarAdmin(admin.ModelAdmin):
     list_display = ('title', 'start_time', 'presenter', 'status',)
     list_filter = ('start_time', 'status', 'language',)
     search_fields = ('title',)
+    raw_id_fields = ('presenter', 'co_hosts', 'panelists')
     readonly_fields = ('created_by', 'modified_by',)
     filter_horizontal = ('co_hosts', 'panelists',)
 
@@ -28,6 +29,12 @@ class WebinarAdmin(admin.ModelAdmin):
         else:
             obj.modified_by = request.user
         obj.save()
+
+    def change_view(self, request, object_id, form_url='', extra_context=None):
+        if '_saveasnew' in request.POST:
+            request.POST = request.POST.copy()
+            request.POST['status'] = Webinar.UPCOMING
+        return self.changeform_view(request, object_id, form_url, extra_context)
 
 
 @admin.register(WebinarRegistration)


### PR DESCRIPTION
[LP-2629](https://philanthropyu.atlassian.net/browse/LP-2629)
[adg-theme-PR](https://github.com/OmnipreneurshipAcademy/adg-edx-theme/pull/206)

Notes:
- Update presenter, co-hosts and panelists fields for model admin i.e. use raw_id_fields.
- Save as new button text is changed to Clone  for webinars
- Handle status of a webinar. Status should be marked as upcoming for cloned webinars.