### PR TITLE
LP-2617 - Send cancellation emails for cohosts, panelists and presenter

### DIFF
--- a/openedx/adg/lms/webinars/helpers.py
+++ b/openedx/adg/lms/webinars/helpers.py
@@ -7,15 +7,16 @@ from openedx.adg.common.lib.mandrill_client.client import MandrillClient
 from openedx.adg.common.lib.mandrill_client.tasks import task_send_mandrill_email
 
 
-def _send_webinar_cancellation_emails(webinar_title, webinar_description, webinar_start_time, recipient_emails):
+def send_webinar_emails(template_slug, webinar_title, webinar_description, webinar_start_time, recipient_emails):
     """
-    Send webinar cancellation email to the list of given email addresses
+    Send webinar email to the list of given email addresses using the given template and data
 
     Arguments:
-        webinar_title (str): Title of the cancelled webinar
-        webinar_description (str): Description of the cancelled webinar
-        webinar_start_time (Datetime): Start datetime of the cancelled webinar
-        recipient_emails (list):  List of Email addresses (str) to send the email to
+        template_slug (str): Slug for the chosen email template
+        webinar_title (str): Title of the webinar
+        webinar_description (str): Description of the webinar
+        webinar_start_time (Datetime): Start datetime of the webinar
+        recipient_emails (list):  List of email addresses (str) to send the email to
 
     Returns:
         None
@@ -26,7 +27,7 @@ def _send_webinar_cancellation_emails(webinar_title, webinar_description, webina
         'webinar_start_time': webinar_start_time.strftime("%B %d, %Y %I:%M %p %Z")
     }
 
-    task_send_mandrill_email.delay(MandrillClient.WEBINAR_CANCELLATION, recipient_emails, context)
+    task_send_mandrill_email.delay(template_slug, recipient_emails, context)
 
 
 def send_cancellation_emails_for_given_webinars(cancelled_webinars):
@@ -51,7 +52,8 @@ def send_cancellation_emails_for_given_webinars(cancelled_webinars):
         if not webinar_email_addresses:
             continue
 
-        _send_webinar_cancellation_emails(
+        send_webinar_emails(
+            MandrillClient.WEBINAR_CANCELLATION,
             cancelled_webinar.title,
             cancelled_webinar.description,
             cancelled_webinar.start_time,

--- a/openedx/adg/lms/webinars/models.py
+++ b/openedx/adg/lms/webinars/models.py
@@ -23,7 +23,8 @@ class WebinarQuerySet(models.QuerySet):
     """
 
     def delete(self):
-        cancelled_upcoming_webinars = self.filter(status=Webinar.UPCOMING)
+        cancelled_upcoming_webinars = self.filter(
+            status=Webinar.UPCOMING).select_related('presenter').prefetch_related('co_hosts', 'panelists')
         send_cancellation_emails_for_given_webinars(cancelled_upcoming_webinars)
         self.update(status=Webinar.CANCELLED)
 

--- a/openedx/adg/lms/webinars/tests/test_helpers.py
+++ b/openedx/adg/lms/webinars/tests/test_helpers.py
@@ -1,9 +1,9 @@
 """
 Tests for all the helpers in webinars app
 """
-import mock
 import pytest
 
+from common.djangoapps.student.tests.factories import UserFactory
 from openedx.adg.common.lib.mandrill_client.client import MandrillClient
 from openedx.adg.lms.webinars.helpers import send_cancellation_emails_for_given_webinars
 
@@ -11,35 +11,71 @@ from .factories import WebinarFactory, WebinarRegistrationFactory
 
 
 @pytest.mark.django_db
-@mock.patch('openedx.adg.lms.webinars.helpers.task_send_mandrill_email')
 @pytest.mark.parametrize(
-    'registered_users_with_response, expected_email_addresses',
+    'registered_users_with_response, cohosts, panelists, presenter, expected_email_addresses',
     [
-        ([], []),
-        ([("test1@example.com", False), ("test2@example.com", False)], []),
-        ([("test1@example.com", True), ("test2@example.com", False)], ["test1@example.com"]),
-        ([("test1@example.com", False), ("test2@example.com", True)], ["test2@example.com"]),
-        ([("test1@example.com", True), ("test2@example.com", True)], ["test1@example.com", "test2@example.com"])
+        (
+            [], [], [], 't3@eg.com', ['t3@eg.com']
+        ),
+        (
+            [('t1@eg.com', False), ('t2@eg.com', False)], [], [], 't3@eg.com', ['t3@eg.com']
+        ),
+        (
+            [('t1@eg.com', True), ('t2@eg.com', False)], ['t1@eg.com'], [], 't3@eg.com', ['t1@eg.com', 't3@eg.com']
+        ),
+        (
+            [('t1@eg.com', False), ('t2@eg.com', True)], [], ['t2@eg.com'], 't3@eg.com', ['t2@eg.com', 't3@eg.com']
+        ),
+        (
+            [('t1@eg.com', False), ('t2@eg.com', False)], ['t1@eg.com'], ['t2@eg.com'], 't3@eg.com',
+            ['t1@eg.com', 't2@eg.com', 't3@eg.com']
+        ),
+        (
+            [('t1@eg.com', True), ('t2@eg.com', True)], ['t4@eg.com'], ['t4@eg.com'], 't3@eg.com',
+            ['t1@eg.com', 't2@eg.com', 't3@eg.com', 't4@eg.com']
+        ),
+        (
+            [('t1@eg.com', True), ('t2@eg.com', True)], ['t4@eg.com'], ['t5@eg.com'], 't3@eg.com',
+            ['t1@eg.com', 't2@eg.com', 't3@eg.com', 't4@eg.com', 't5@eg.com']
+        ),
+        (
+            [('t1@eg.com', True)], ['t4@eg.com', 't5@eg.com'], ['t5@eg.com', 't6@eg.com'], 't3@eg.com',
+            ['t1@eg.com', 't3@eg.com', 't4@eg.com', 't5@eg.com', 't6@eg.com']
+        )
     ]
 )
 def test_send_cancellation_emails_for_given_webinars(
-    mocked_task_send_mandrill_email, registered_users_with_response, expected_email_addresses
+    mocker, registered_users_with_response, cohosts, panelists, presenter, expected_email_addresses
 ):
     """
-    Test if emails are sent to different registered users
+    Test if emails are sent to all the registered users, co-hosts, panelists and the presenter without any duplicates
     """
-    webinar = WebinarFactory()
+    mocked_task_send_mandrill_email = mocker.patch('openedx.adg.lms.webinars.helpers.task_send_mandrill_email')
+
+    webinar = WebinarFactory(presenter__email=presenter)
     for email, invite_response in registered_users_with_response:
         WebinarRegistrationFactory(user__email=email, webinar=webinar, is_registered=invite_response)
 
+    for cohost_email in cohosts:
+        cohost = UserFactory(email=cohost_email)
+        webinar.co_hosts.add(cohost)
+        webinar.save()
+
+    for panelist_email in panelists:
+        panelist = UserFactory(email=panelist_email)
+        webinar.panelists.add(panelist)
+        webinar.save()
+
     send_cancellation_emails_for_given_webinars([webinar])
 
-    context = {
+    expected_context = {
         'webinar_title': webinar.title,
         'webinar_description': webinar.description,
         'webinar_start_time': webinar.start_time.strftime("%B %d, %Y %I:%M %p %Z")
     }
 
-    if expected_email_addresses:
-        mocked_task_send_mandrill_email.delay.assert_called_with(
-            MandrillClient.WEBINAR_CANCELLATION, expected_email_addresses, context)
+    actual_template, actual_email_addresses, actual_context = mocked_task_send_mandrill_email.delay.call_args.args
+
+    assert actual_template == MandrillClient.WEBINAR_CANCELLATION
+    assert actual_context == expected_context
+    assert sorted(actual_email_addresses) == sorted(expected_email_addresses)


### PR DESCRIPTION

[LP-2617](https://philanthropyu.atlassian.net/browse/LP-2617)

- Send emails to the presenter, panelists, and co-hosts in addition to the registered users.
- Make sure an email address gets only a single email per cancellation.
- Add/Modify unit tests to cover all the edge cases.
