### PR TITLE
LP-2649 - Add ADG Admin link in profile dropdown for admin users

### DIFF
--- a/openedx/adg/lms/applications/helpers.py
+++ b/openedx/adg/lms/applications/helpers.py
@@ -22,6 +22,7 @@ from .constants import (
     MONTH_NAME_DAY_YEAR_FORMAT,
     SCORES
 )
+from .rules import is_adg_admin
 
 
 def validate_logo_size(file_):
@@ -268,3 +269,19 @@ def get_extra_context_for_application_review_page(application):
     }
 
     return extra_context
+
+
+def has_admin_permissions(user):
+    """
+    Checks if the user is a superuser or an ADG admin or the admin of any business line while having the staff status
+
+    Arguments:
+        user (User): User object to check for permissions
+
+    Returns:
+        boolean: True if the user has admin permissions of any kind else False
+    """
+    from openedx.adg.lms.applications.models import BusinessLine
+
+    is_user_admin = user.is_superuser or is_adg_admin(user) or BusinessLine.is_user_business_line_admin(user)
+    return user.is_staff and is_user_admin

--- a/openedx/adg/lms/applications/models.py
+++ b/openedx/adg/lms/applications/models.py
@@ -116,6 +116,19 @@ class BusinessLine(TimeStampedModel):
     class Meta:
         app_label = 'applications'
 
+    @classmethod
+    def is_user_business_line_admin(cls, user):
+        """
+        Checks if the user is a business line admin i.e Belongs to atleast one business line group
+
+        Arguments:
+             user (User): User object to check permissions for
+
+        Returns:
+            boolean: Returns True if the user is an admin and False if not
+        """
+        return cls.objects.filter(group__user=user).exists()
+
     def __str__(self):
         return '{}'.format(self.title)
 


### PR DESCRIPTION
[LP-2649](https://philanthropyu.atlassian.net/browse/LP-2649)

- Display a dropdown option  for `adg-admin` page if the logged in user is an ADG Admin or a Business Line Admin, or a Superuser.

[Theme PR](https://github.com/OmnipreneurshipAcademy/adg-edx-theme/pull/224)