### PR TITLE
LP-2673 Tech doc for branding_extension, courseware_override & out_team apps

### DIFF
--- a/openedx/adg/lms/branding_extension/__init__.py
+++ b/openedx/adg/lms/branding_extension/__init__.py
@@ -1,0 +1,4 @@
+"""
+This app provides functions and features related to branding of ADG website, i.e. navigation links on footer,
+copyright info etc.
+"""

--- a/openedx/adg/lms/courseware_override/__init__.py
+++ b/openedx/adg/lms/courseware_override/__init__.py
@@ -1,3 +1,4 @@
 """
-Override for courseware application
+This app provides ability to override core courseware functionality provided by edx. This app contains helper
+functions which are injected in core code to override its functionality. Relevant unit tests are also updated.
 """

--- a/openedx/adg/lms/our_team/__init__.py
+++ b/openedx/adg/lms/our_team/__init__.py
@@ -1,5 +1,6 @@
 """
-init file for our team
+This app adds the ability to manage team members and board members, dynamically. New team and board members
+can be added from Django admin, similarly they can be updated from Django admin. ADG LMS site's 'Our Team' page
+displays all the members added from Django admin.
 """
-
 default_app_config = 'openedx.adg.lms.our_team.apps.OurTeamConfig'


### PR DESCRIPTION

**[LP-2673](https://philanthropyu.atlassian.net/browse/LP-2673)** Tech doc for branding_extension, courseware_override & out_team apps

Note: Tech doc for course_meta is already covered in this [PR](https://github.com/OmnipreneurshipAcademy/edx-platform/pull/289)