### PR TITLE
LP-2698 webinar registration delete permission from admin

### DIFF
--- a/openedx/adg/lms/webinars/admin.py
+++ b/openedx/adg/lms/webinars/admin.py
@@ -187,6 +187,26 @@ class WebinarAdmin(WebinarAdminBase):
         qs = super(WebinarAdmin, self).get_queryset(request)
         return qs.filter(is_cancelled=False)
 
+    def get_deleted_objects(self, objs, request):
+        """
+        Overriding this method to prevent delete permissions error on related objects when a webinar is
+        deleted (cancelled) from admin site.
+
+        We have overridden the delete method of Webinar model to mark a webinar as cancelled, instead of deleting it.
+        Once the webinar is deleted (cancelled) from admin site, the delete view gets a list of related objects by
+        calling get_deleted_objects method and checks for admin’s delete permission of those related objects, which
+        includes webinar registrations. Since webinar registration’s delete permission is revoked from the admin site,
+        the admin delete view show a permission error and does not allow to proceed with the cancellation of the
+        webinar. To bypass the permission error, we are overriding this method.
+
+        Note: deleting (cancelling) a webinar does not delete its corresponding webinar registrations, we only need the
+        permission so that the webinar can be cancelled successfully
+        """
+        deleted_objects, model_count, perms_needed, protected = super().get_deleted_objects(
+                                                                                        objs, request
+                                                                                        )  # pylint: unused-variable
+        return deleted_objects, model_count, set(), protected
+
 
 class CancelledWebinarAdmin(WebinarAdminBase):
     """

--- a/openedx/adg/lms/webinars/tests/test_admin.py
+++ b/openedx/adg/lms/webinars/tests/test_admin.py
@@ -268,3 +268,14 @@ def test_registration_webinar_admin_delete_permission():
     Test that admins do not have permission to delete webinar registrations
     """
     assert not WebinarRegistrationAdmin.has_delete_permission('self', Mock())
+
+
+@pytest.mark.django_db
+def test_get_deleted_objects_webinar_admin(webinar_admin_instance, request, webinar):
+    """
+    Test that get_deleted_objects for webinar admin returns an empty set of permissions
+    """
+    request.user = UserFactory()
+    deleted_objects, model_count, perms_needed, protected = webinar_admin_instance.get_deleted_objects([webinar],
+                                                                                                       request)
+    assert perms_needed == set()


### PR DESCRIPTION
- fix for allowing user to change the webinar status to canceled