### PR TITLE
LP-2699 - Add urls and view for Application Introduction view

### DIFF
--- a/openedx/adg/lms/applications/urls.py
+++ b/openedx/adg/lms/applications/urls.py
@@ -5,6 +5,7 @@ from django.urls import path
 
 from .views import (
     ApplicationHubView,
+    ApplicationIntroductionView,
     ApplicationSuccessView,
     ContactInformationView,
     CoverLetterView,
@@ -13,6 +14,7 @@ from .views import (
 
 urlpatterns = [
     path('', ApplicationHubView.as_view(), name='application_hub'),
+    path('introduction', ApplicationIntroductionView.as_view(), name='application_introduction'),
     path('contact', ContactInformationView.as_view(), name='application_contact'),
     path('education_experience', EducationAndExperienceView.as_view(), name='application_education_experience'),
     path('cover_letter', CoverLetterView.as_view(), name='application_cover_letter'),

--- a/openedx/adg/lms/applications/urls.py
+++ b/openedx/adg/lms/applications/urls.py
@@ -13,8 +13,8 @@ from .views import (
 )
 
 urlpatterns = [
-    path('', ApplicationHubView.as_view(), name='application_hub'),
-    path('introduction', ApplicationIntroductionView.as_view(), name='application_introduction'),
+    path('', ApplicationIntroductionView.as_view(), name='application_introduction'),
+    path('progress', ApplicationHubView.as_view(), name='application_hub'),
     path('contact', ContactInformationView.as_view(), name='application_contact'),
     path('education_experience', EducationAndExperienceView.as_view(), name='application_education_experience'),
     path('cover_letter', CoverLetterView.as_view(), name='application_cover_letter'),

--- a/openedx/adg/lms/applications/views.py
+++ b/openedx/adg/lms/applications/views.py
@@ -422,3 +422,12 @@ class ApplicationIntroductionView(RedirectToLoginOrRelevantPageMixin, TemplateVi
 
     login_url = reverse_lazy('register_user')
     template_name = 'adg/lms/applications/introduction.html'
+
+    def is_precondition_satisfied(self):
+        """
+        Checks if a user has visited the application hub page i.e ApplicationHub object for current user exists or not
+
+        Returns:
+            bool: True if user has visited the hub page else False
+        """
+        return not ApplicationHub.objects.filter(user=self.request.user).exists()

--- a/openedx/adg/lms/applications/views.py
+++ b/openedx/adg/lms/applications/views.py
@@ -413,3 +413,12 @@ class CoverLetterView(RedirectToLoginOrRelevantPageMixin, View):
             application_hub.set_is_written_application_completed()
 
             return redirect('application_hub')
+
+
+class ApplicationIntroductionView(RedirectToLoginOrRelevantPageMixin, TemplateView):
+    """
+    View for Application introduction page
+    """
+
+    login_url = reverse_lazy('register_user')
+    template_name = 'adg/lms/applications/introduction.html'


### PR DESCRIPTION
- Add view and url for Application Introduction View
- Changed the urls for introduction and hub to `application/` and `application/progress/` respectively
- User is only allowed to visit Application Introduction page when the user is authenticated and the user has not clicked the `Start Application` button on the Application Introduction page prior to that point. Once the Introduction page's `Start Application` button has been pressed by the user, an ApplicationHub object is created for that particular user and from that point onward that user is redirected to the Application Hub page whenever they try to land on the Introduction page.