### PR TITLE
LP-2697 Add support link in footer

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4113,3 +4113,6 @@ NOTIFICATION_FROM_EMAIL = 'info@omnipreneurshipacademy.com'
 
 # CDN link for s3 amazon aws server
 CDN_LINK = 'https://static.omnipreneurshipacademy.com/'
+
+# ADG zendesk support help desk link
+SUPPORT_LINK = 'https://support.omnipreneurshipacademy.com/'

--- a/openedx/adg/lms/branding_extension/constants.py
+++ b/openedx/adg/lms/branding_extension/constants.py
@@ -1,0 +1,5 @@
+"""
+Constants for branding extension
+"""
+TARGET_BLANK = '_blank'
+TARGET_SELF = '_self'

--- a/openedx/adg/lms/branding_extension/helpers.py
+++ b/openedx/adg/lms/branding_extension/helpers.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from common.djangoapps.edxmako.shortcuts import marketing_link
+from openedx.adg.lms.branding_extension.constants import TARGET_BLANK, TARGET_SELF
 from openedx.adg.lms.utils.env_utils import is_testing_environment
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
@@ -21,18 +22,20 @@ def get_footer_navigation_links():
         List, which contains dictionaries of url
     """
     links = [
-        (marketing_link('ABOUT'), _('About')),
-        (reverse('our_team'), _('Our Team')),
-        (marketing_link('TOS'), _('Terms')),
-        (marketing_link('CONTACT'), _('Contact')),
+        (marketing_link('ABOUT'), _('About'), TARGET_SELF),
+        (reverse('our_team'), _('Our Team'), TARGET_SELF),
+        (marketing_link('CONTACT'), _('Contact'), TARGET_SELF),
+        (settings.SUPPORT_LINK, _('Support'), TARGET_BLANK),
+        (marketing_link('TOS'), _('Terms'), TARGET_SELF),
     ]
 
     return [
         {
             'url': link_url,
             'title': link_title,
+            'target': target,
         }
-        for link_url, link_title in links
+        for link_url, link_title, target in links
     ]
 
 

--- a/openedx/adg/lms/branding_extension/tests/helpers_tests.py
+++ b/openedx/adg/lms/branding_extension/tests/helpers_tests.py
@@ -3,10 +3,12 @@ Tests for helpers of branding_extension app
 """
 import mock
 import pytest
+from django.conf import settings
 from django.test import RequestFactory
 from django.urls import reverse
 from freezegun import freeze_time
 
+from openedx.adg.lms.branding_extension.constants import TARGET_BLANK, TARGET_SELF
 from openedx.adg.lms.branding_extension.helpers import (
     get_copyright,
     get_footer_navigation_links,
@@ -22,23 +24,32 @@ def test_get_footer_navigation_links(mocker):
     mocker.patch('openedx.adg.lms.branding_extension.helpers.marketing_link', return_value=test_url)
 
     branding_links = get_footer_navigation_links()
-    assert len(branding_links) == 4
+    assert len(branding_links) == 5
     assert branding_links == [
         {
             'url': test_url,
             'title': 'About',
+            'target': TARGET_SELF,
         },
         {
             'url': reverse('our_team'),
             'title': 'Our Team',
-        },
-        {
-            'url': test_url,
-            'title': 'Terms',
+            'target': TARGET_SELF,
         },
         {
             'url': test_url,
             'title': 'Contact',
+            'target': TARGET_SELF,
+        },
+        {
+            'url': settings.SUPPORT_LINK,
+            'title': 'Support',
+            'target': TARGET_BLANK,
+        },
+        {
+            'url': test_url,
+            'title': 'Terms',
+            'target': TARGET_SELF,
         },
     ]
 


### PR DESCRIPTION
- Add ADG zendesk support link in settings
- Append that link in navigation links
- Reorder links as per the new desings
- Add curtom href target support in footer navigation links

[Theme PR](https://github.com/OmnipreneurshipAcademy/adg-edx-theme/pull/303)