### PR TITLE
LP-2719 - Update admin application review page

### DIFF
--- a/openedx/adg/lms/applications/constants.py
+++ b/openedx/adg/lms/applications/constants.py
@@ -21,6 +21,8 @@ FILE_MAX_SIZE = 4 * 1024 * 1024
 
 APPLICANT_INFO = _('APPLICANT INFORMATION')
 
+BACKGROUND_QUESTION_TITLE = _('BACKGROUND QUESTION')
+
 INTEREST = _('INTEREST IN BUSINESS LINE')
 
 SCORES = _('SCORES')
@@ -38,6 +40,8 @@ ORGANIZATION = 'organization'
 APPLYING_TO = 'applying_to'
 INTEREST_IN_BUSINESS = 'interest_in_business'
 PREREQUISITES = 'prerequisites'
+HEAR_ABOUT_OMNI = 'hear_about_omni'
+BACKGROUND_QUESTION = 'background_question'
 
 # Application listing page titles
 

--- a/openedx/adg/lms/applications/tests/constants.py
+++ b/openedx/adg/lms/applications/tests/constants.py
@@ -20,11 +20,15 @@ NOTE = 'Test note'
 LINKED_IN_URL = 'Test LinkedIn URL'
 
 ALL_FIELDSETS = (
-    'preliminary_info_fieldset', 'applicant_info_fieldset', 'interest_fieldset', 'scores_fieldset'
+    'preliminary_info_fieldset',
+    'applicant_info_fieldset',
+    'background_question_fieldset',
+    'interest_fieldset',
+    'scores_fieldset',
 )
 
 TEST_INTEREST_IN_BUSINESS = 'Test Interest in Business'
-
+TEST_HEAR_ABOUT_OMNI = 'Test Hear about Omni'
 TEST_BACKGROUND_QUESTION = 'Test background question'
 
 TEST_TEXT_INPUT = 'Test '

--- a/openedx/adg/lms/applications/tests/factories.py
+++ b/openedx/adg/lms/applications/tests/factories.py
@@ -98,6 +98,7 @@ class MultilingualCourseGroupFactory(factory.DjangoModelFactory):
 
     name = factory.Sequence(lambda n: 'Course group #%s' % n)
     is_program_prerequisite = True
+    is_common_business_line_prerequisite = False
 
     class Meta:
         model = MultilingualCourseGroup


### PR DESCRIPTION
[LP-2719](https://philanthropyu.atlassian.net/browse/LP-2719)

- Add `hear_about_omni` field in the Application Info fieldset
- Add a fieldset for `Interest in Program` and `Background Question` fields
- Add references section by creating an inline for `references` similar to Education & Experience
- Add course scores for both program and BU prereq courses in the prerequisites (scores) fieldset
- Only allow an admin to submit an application when all the prereq courses have been cleared i.e program prereqs and business_line prereqs