### PR TITLE
LP-2721 Fix timezone for webinar reminder emails

### DIFF
--- a/openedx/adg/lms/helpers.py
+++ b/openedx/adg/lms/helpers.py
@@ -21,7 +21,7 @@ def convert_date_time_zone_and_format(date_time_object, time_zone, time_format):
     """
     Change time zone of datetime object and return a formatted string
     Args:
-        date_time_object (datetime): datetime object
+        date_time_object (datetime.datetime): datetime object
         time_zone (string): a time zone string
         time_format (string): a time format string
     Returns:

--- a/openedx/adg/lms/webinars/constants.py
+++ b/openedx/adg/lms/webinars/constants.py
@@ -21,3 +21,4 @@ WEBINAR_STATUS_UPCOMING = _('Upcoming')
 WEBINARS_TIME_FORMAT = '%B %d, %Y %I:%M %p %Z'
 
 SEND_UPDATE_EMAILS_FIELD = 'send_update_emails'
+UTC_TIMEZONE_HELP_TEXT = _('Please add the time in UTC timezone.')

--- a/openedx/adg/lms/webinars/forms.py
+++ b/openedx/adg/lms/webinars/forms.py
@@ -6,6 +6,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from openedx.adg.lms.webinars.models import Webinar
 
+from .constants import UTC_TIMEZONE_HELP_TEXT
 from .helpers import validate_email_list
 
 
@@ -13,6 +14,7 @@ class WebinarForm(forms.ModelForm):
     """
     Webinar Form to create/edit a webinar from admin side
     """
+
     invites_by_email_address = forms.CharField(
         required=False,
         widget=forms.Textarea,
@@ -29,6 +31,10 @@ class WebinarForm(forms.ModelForm):
     class Meta:
         model = Webinar
         fields = '__all__'
+        help_texts = {
+            'start_time': UTC_TIMEZONE_HELP_TEXT,
+            'end_time': UTC_TIMEZONE_HELP_TEXT,
+        }
 
     def clean_invites_by_email_address(self):
         """

--- a/openedx/adg/lms/webinars/helpers.py
+++ b/openedx/adg/lms/webinars/helpers.py
@@ -12,9 +12,16 @@ from django.urls import reverse
 
 from openedx.adg.common.lib.mandrill_client.client import MandrillClient
 from openedx.adg.common.lib.mandrill_client.tasks import task_cancel_mandrill_emails, task_send_mandrill_email
+from openedx.adg.lms.helpers import convert_date_time_zone_and_format
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
-from .constants import ONE_WEEK_REMINDER_ID_FIELD_NAME, STARTING_SOON_REMINDER_ID_FIELD_NAME, WEBINAR_DATE_TIME_FORMAT
+from .constants import (
+    ONE_WEEK_REMINDER_ID_FIELD_NAME,
+    STARTING_SOON_REMINDER_ID_FIELD_NAME,
+    WEBINAR_DATE_TIME_FORMAT,
+    WEBINAR_DEFAULT_TIME_ZONE,
+    WEBINARS_TIME_FORMAT
+)
 
 
 def send_webinar_emails(template_slug, webinar, recipient_emails, send_at=None):
@@ -134,7 +141,10 @@ def schedule_webinar_reminders(user_emails, email_context):
     Returns:
         None
     """
-    webinar_start_time = datetime.strptime(email_context['webinar_start_time'], WEBINAR_DATE_TIME_FORMAT)
+    webinar_start_time = datetime.strptime(email_context['webinar_start_time'], WEBINARS_TIME_FORMAT)
+    email_context['webinar_start_time'] = convert_date_time_zone_and_format(
+        webinar_start_time, WEBINAR_DEFAULT_TIME_ZONE, WEBINAR_DATE_TIME_FORMAT
+    )
 
     task_send_mandrill_email.delay(
         MandrillClient.WEBINAR_TWO_HOURS_REMINDER,

--- a/openedx/adg/lms/webinars/models.py
+++ b/openedx/adg/lms/webinars/models.py
@@ -14,6 +14,7 @@ from model_utils.models import TimeStampedModel
 
 from openedx.adg.lms.applications.helpers import validate_file_size
 from openedx.adg.lms.helpers import convert_date_time_zone_and_format
+from openedx.adg.lms.webinars.constants import WEBINARS_TIME_FORMAT
 from openedx.core.djangoapps.theming.helpers import get_current_request
 
 from .constants import (
@@ -124,7 +125,7 @@ class Webinar(TimeStampedModel):
             'webinar_id': self.id,
             'webinar_title': self.title,
             'webinar_description': self.description,
-            'webinar_start_time': self.start_date_time_AST,
+            'webinar_start_time': self.start_time.strftime(WEBINARS_TIME_FORMAT),
             'webinar_meeting_link': self.meeting_link,
         }
 


### PR DESCRIPTION
[LP-2721](https://philanthropyu.atlassian.net/browse/LP-2721)

- Used UTC time for scheduling the emails.

- For now I have added a help text for the admins that the time they are adding is in UTC. We will incorporate the 2nd expected result in phase 2, in which we will create dedicated dashboard for admins.