### PR TITLE
LP-2753 Inconsistent Behaviour of Validation Messages on Registration Page

### DIFF
--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -549,11 +549,18 @@
                 liveValidate: function($el) {
                     var data = {},
                         field,
+                        field_value,
                         i;
+
                     for (i = 0; i < this.liveValidationFields.length; ++i) {
                         field = this.liveValidationFields[i];
-                        data[field] = $('#register-' + field).val();
+                        field_value = $('#register-' + field).val();
+
+                        if (field_value) {
+                          data[field] = field_value;
+                        }
                     }
+
                     FormView.prototype.liveValidate(
                         $el, this.validationUrl, 'json', data, 'POST', this.model
                     );


### PR DESCRIPTION
[Inconsistent Behaviour of Validation Messages on Registration Page](https://philanthropyu.atlassian.net/browse/LP-2753)

We were sending field validation for all fields even if we don't have data of that field in front-end.
So here I've added a check to send only those fields to validate which have some data.