### PR TITLE
LP-2754 update view to send email

### DIFF
--- a/openedx/adg/lms/applications/helpers.py
+++ b/openedx/adg/lms/applications/helpers.py
@@ -589,6 +589,37 @@ def get_omnipreneurship_courses_instructions(course_cards):
     }
 
 
+def update_application_hub_and_send_submission_email_if_applicable(
+    user_application_hub, are_pre_req_courses_completed, are_bu_courses_completed
+):
+    """
+    Updates the application hub flags based on the values of `are_pre_req_courses_completed` and
+    `are_bu_courses_completed` and checks if all the steps for application have been completed, if so, sends
+    application submission confirmation email.
+
+    Arguments:
+        user_application_hub (ApplicationHub): ApplicationHub object for a user
+        are_pre_req_courses_completed (bool): indicating if all prerequisite courses have been passed
+        are_bu_courses_completed (bool): indicating if all business unit courses have been passed
+    """
+    if not user_application_hub.are_application_pre_reqs_completed():
+        is_any_flag_changed = False
+
+        if not user_application_hub.is_prerequisite_courses_passed and are_pre_req_courses_completed:
+            user_application_hub.is_prerequisite_courses_passed = True
+            is_any_flag_changed = True
+
+        if not user_application_hub.is_bu_prerequisite_courses_passed and are_bu_courses_completed:
+            user_application_hub.is_bu_prerequisite_courses_passed = True
+            is_any_flag_changed = True
+
+        if is_any_flag_changed:
+            user_application_hub.save()
+
+        if user_application_hub.are_application_pre_reqs_completed():
+            send_application_submission_confirmation_emails([user_application_hub.user.email])
+
+
 def replace_last_comma_occurrences(string):
     """
     Removes the trailing comma and replaces the last remaining comma (if any) with 'and'

--- a/openedx/adg/lms/applications/tests/test_views.py
+++ b/openedx/adg/lms/applications/tests/test_views.py
@@ -234,6 +234,7 @@ def test_get_initial_application_state_for_application_hub_view(application_hub_
     """
     mocker.patch('openedx.adg.lms.applications.views.get_application_hub_instructions', return_value={})
     mocker.patch('openedx.adg.lms.applications.views.get_omnipreneurship_courses_instructions', return_value={})
+    mocker.patch('openedx.adg.lms.applications.views.update_application_hub_and_send_submission_email_if_applicable')
     mock_render = mocker.patch('openedx.adg.lms.applications.views.render')
 
     ApplicationHubFactory(user=application_hub_view_get_request.user)
@@ -272,6 +273,7 @@ def test_each_step_for_application_completion_application_hub_view(
         'openedx.adg.lms.applications.views.get_course_cards_and_gross_details',
         return_value=([], False, False)
     )
+    mocker.patch('openedx.adg.lms.applications.views.update_application_hub_and_send_submission_email_if_applicable')
     mock_render = mocker.patch('openedx.adg.lms.applications.views.render')
 
     application_hub = ApplicationHubFactory(user=application_hub_view_get_request.user)

--- a/openedx/adg/lms/applications/views.py
+++ b/openedx/adg/lms/applications/views.py
@@ -23,7 +23,8 @@ from openedx.adg.lms.utils.date_utils import month_choices, year_choices
 from .helpers import (
     get_application_hub_instructions,
     get_course_cards_and_gross_details,
-    get_omnipreneurship_courses_instructions
+    get_omnipreneurship_courses_instructions,
+    update_application_hub_and_send_submission_email_if_applicable
 )
 from .models import ApplicationHub, BusinessLine, Education, MultilingualCourseGroup, UserApplication
 
@@ -129,14 +130,12 @@ class ApplicationHubView(RedirectToLoginOrRelevantPageMixin, View):
                 )
             )
 
-        user_application_hub.is_prerequisite_courses_passed = are_pre_req_courses_completed
-        user_application_hub.is_bu_prerequisite_courses_passed = are_bu_courses_completed
-        user_application_hub.save()
+        update_application_hub_and_send_submission_email_if_applicable(
+            user_application_hub, are_pre_req_courses_completed, are_bu_courses_completed
+        )
 
         messages = get_application_hub_instructions(
-            user_application_hub,
-            is_any_prerequisite_started,
-            is_any_bu_course_started
+            user_application_hub, is_any_prerequisite_started, is_any_bu_course_started
         )
 
         instructions = get_omnipreneurship_courses_instructions(pre_req_courses)


### PR DESCRIPTION
[Ticket](https://philanthropyu.atlassian.net/browse/LP-2754) 
[Bug](https://philanthropyu.atlassian.net/browse/LP-2754)

At first we were sending email of application submission through command. Now that the application hub flags are updating in the view we also need to send email of submission when the user completes all the steps. Following code changes were made to accommodate that.