### PR TITLE
Revert "LP-2753 Inconsistent Behaviour of Validation Messages on Registration Page"

### DIFF
--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -549,18 +549,11 @@
                 liveValidate: function($el) {
                     var data = {},
                         field,
-                        field_value,
                         i;
-
                     for (i = 0; i < this.liveValidationFields.length; ++i) {
                         field = this.liveValidationFields[i];
-                        field_value = $('#register-' + field).val();
-
-                        if (field_value) {
-                          data[field] = field_value;
-                        }
+                        data[field] = $('#register-' + field).val();
                     }
-
                     FormView.prototype.liveValidate(
                         $el, this.validationUrl, 'json', data, 'POST', this.model
                     );


### PR DESCRIPTION
Reverts OmnipreneurshipAcademy/edx-platform#415


Reason: We don't need this change. Because its an OpenEdx issue which I think, they have resolved in their latest master branch. 
This issue was mainly reported because Automation test cases were failing after few hits to API, the reason is we have set the RateLimit = 30 hits per week (30/7d) for Registration API, And after 30 hits it throws 403 forbidden error. So that is the main issue which should be resolved. I've created separate [ticket](https://philanthropyu.atlassian.net/jira/software/projects/DDO/boards/10?selectedIssue=DDO-64) for this