### PR TITLE
LP-2766 Use ORA2 Xblock by edX for testing

### DIFF
--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -188,7 +188,7 @@ nodeenv==1.5.0            # via -r requirements/edx/base.txt
 numpy==1.18.5             # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.9       # via -r requirements/edx/base.txt
-git+https://github.com/OmnipreneurshipAcademy/edx-ora2.git@${ADG_XBLOCKS_BRANCH}#egg=ora2            # via -r requirements/edx/base.txt
+ora2==2.11.5.1            # via -r requirements/edx/base.txt
 packaging==20.4           # via -r requirements/edx/base.txt, bleach, drf-yasg, pytest, tox
 path.py==12.5.0           # via -r requirements/edx/base.txt, edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, path.py


### PR DESCRIPTION
[LP-2766](https://philanthropyu.atlassian.net/browse/LP-2766)

To make updates in ORA2, we forked it and made changes in it. Due to these changes core unit test started failing. 
I have updated to install the parent ORA2 xblock from edX as it was previously for the tests. We did the same for `msp-assessment` xblock.